### PR TITLE
Adds ca-certificates package to ta container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:12
 RUN apt update
-RUN apt install redis -y
+RUN apt install redis ca-certificates curl -y
 ENV PYTHONUNBUFFERED=1
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
With this `/resolve` endpoint now works again, inside of the container.