### PR TITLE
Fixes /resolve endpoint logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,20 +57,6 @@ exclude = [
     "venv",
     "django_redis",
 ]
-lint.select = [
-    # pycodestyle
-    "E",
-    # Pyflakes
-    "F",
-    # pyupgrade
-    "UP",
-    # flake8-bugbear
-    "B",
-    # flake8-simplify
-    "SIM",
-    # isort
-    "I",
-]
 
 [tool.ty.src]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,20 @@ exclude = [
     "site-packages",
     "venv",
 ]
-
+lint.select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
 
 [tool.ty.src]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
+    "django_redis",
 ]
 lint.select = [
     # pycodestyle

--- a/src/bin/inmor/main.rs
+++ b/src/bin/inmor/main.rs
@@ -165,16 +165,16 @@ async fn main() -> io::Result<()> {
             let x = metadata.as_object().unwrap();
             if x.contains_key("openid_provider") {
                 // Means OP
-                let entity = EntityDetails::new(&key, "openid_provider", trustmarks);
+                let entity = EntityDetails::new(key, "openid_provider", trustmarks);
                 fe.insert(key.clone(), entity);
             } else if x.contains_key("openid_relying_party") {
                 // Means RP
-                let entity = EntityDetails::new(&key, "openid_relying_party", trustmarks);
+                let entity = EntityDetails::new(key, "openid_relying_party", trustmarks);
 
                 fe.insert(key.clone(), entity);
             } else {
                 // Means TA/IA
-                let entity = EntityDetails::new(&key, "taia", trustmarks);
+                let entity = EntityDetails::new(key, "taia", trustmarks);
                 fe.insert(key.clone(), entity);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,9 +438,9 @@ async fn list_subordinates(
     if let Some(inter) = intermediate {
         // Means we should only provide any intermediate subordinate
         results.retain(|x| match x.entity_type.as_str() {
-                "taia" => inter, // When we asked for intermediate
-                _ => !inter,     // When we want to the rest
-            });
+            "taia" => inter, // When we asked for intermediate
+            _ => !inter,     // When we want to the rest
+        });
     }
 
     if let Some(trust_marked) = trust_marked {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl EntityDetails {
         EntityDetails {
             entity_id: entity_id.to_string(),
             entity_type: entity_type.to_string(),
-            has_trustmark: has_trustmark,
+            has_trustmark,
             trustmarks: tms,
         }
     }
@@ -432,26 +432,20 @@ async fn list_subordinates(
     // Now let us go through the list if we need to filter based on the query parameter.
     if let Some(etype) = entity_type {
         // Means an entity_type was passed.
-        results = results
-            .into_iter()
-            .filter(|x| etype.contains(&x.entity_type))
-            .collect();
+        results.retain(|x| etype.contains(&x.entity_type));
     }
 
     if let Some(inter) = intermediate {
         // Means we should only provide any intermediate subordinate
-        results = results
-            .into_iter()
-            .filter(|x| match x.entity_type.as_str() {
+        results.retain(|x| match x.entity_type.as_str() {
                 "taia" => inter, // When we asked for intermediate
                 _ => !inter,     // When we want to the rest
-            })
-            .collect();
+            });
     }
 
     if let Some(trust_marked) = trust_marked {
         // Means check if at least one trustmark exists
-        results = results.into_iter().filter(|x| x.has_trustmark).collect();
+        results.retain(|x| x.has_trustmark);
     }
 
     let res: Vec<String> = results.iter().map(|x| x.entity_id.clone()).collect();


### PR DESCRIPTION
- The nodes visited is now passed into the recursive calls.
- While applying metadata policy, if no policy then all given metadata is valid.
- Remove any extra key/values for final policy, these might come from the metadata.