### PR TITLE
Pages for trustmark types

### DIFF
--- a/admin/inmoradmin/urls.py
+++ b/admin/inmoradmin/urls.py
@@ -18,8 +18,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from . import views
+
 urlpatterns = [
     path("trustmarks/", include("trustmarks.urls")),
     path("entities/", include("entities.urls")),
     path("admin/", admin.site.urls),
+    path("", views.index),
 ]

--- a/admin/inmoradmin/views.py
+++ b/admin/inmoradmin/views.py
@@ -1,0 +1,6 @@
+from django.http import HttpRequest
+from django.shortcuts import render
+
+
+def index(request: HttpRequest):
+    return render(request, "index.html")

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -76,6 +76,22 @@
                             </li>
                             <li>
 
+                                <a href="{% url 'trustmarks:type_index' %}" class="nav-link px-0"> <span
+                                        class="d-none d-sm-inline text-white">Trustmark types</span>
+                                </a>
+                                <ul class="collapse show nav flex-column ms-1" id="submenu1" data-bs-parent="#menu">
+                                    <li class="w-100">
+                                        <a href="{% url 'trustmarks:add_type' %}"  class="nav-link px-0"> <span
+                                                class="d-none d-sm-inline text-white">Add Trustmark type</span>
+                                        </a>
+                                        <a href="{% url 'trustmarks:list_types' %}"  class="nav-link px-0"> <span
+                                                class="d-none d-sm-inline text-white">List Trustmark types</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li>
+
                                 <a href="{% url 'entities:index' %}" class="nav-link px-0"> <span
                                         class="d-none d-sm-inline text-white">Subordinates</span>
                                 </a>

--- a/admin/templates/index.html
+++ b/admin/templates/index.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container-md m-5">
 
-    <h2>index page for trust marks</h2>
+    <h2>Index page</h2>
 
 </div>
 {% endblock %}

--- a/admin/templates/trustmark_types/add.html
+++ b/admin/templates/trustmark_types/add.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container-md m-5">
+
+    <h2>Add new Trust mark type</h2>
+    <div class="mb-3">
+    <form method="post">
+      {% csrf_token %}
+      <div class="mb-3">
+        <input type="text" class="form-control" name="type" id="id_type">
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+    </div>
+
+    <div class="mb-3">
+      {{ msg }}
+    </div>
+
+
+</div>
+{% endblock %}

--- a/admin/templates/trustmark_types/index.html
+++ b/admin/templates/trustmark_types/index.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container-md m-5">
 
-    <h2>index page for trust marks</h2>
+    <h2>Index page for trust mark types</h2>
 
 </div>
 {% endblock %}

--- a/admin/templates/trustmark_types/list.html
+++ b/admin/templates/trustmark_types/list.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container-md m-5">
+
+  <div class="m-5">
+    <h2>Existing Trust Mark Types</h2>
+  </div>
+  <div class="m-5">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">Trust Mark Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for tmt in page_obj %}
+        <tr>
+          <td>{{ tmt.tmtype }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <div class="pagination">
+      <span class="step-links">
+        {% if page_obj.has_previous %}
+        <a href="?page=1">&laquo; first</a>
+        <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+        {% endif %}
+
+        <span class="current">
+          Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+        </span>
+
+        {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}">next</a>
+        <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
+        {% endif %}
+      </span>
+    </div>
+  </div>
+
+
+</div>
+{% endblock %}

--- a/admin/trustmarks/forms.py
+++ b/admin/trustmarks/forms.py
@@ -6,3 +6,7 @@ from .models import TrustMarkType
 class TrustMarkForm(forms.Form):
     entity = forms.CharField(label="entity")
     tmt_select = forms.ModelChoiceField(queryset=TrustMarkType.objects.all())
+
+
+class TrustMarkTypeForm(forms.Form):
+    type = forms.CharField(label="trust mark type")

--- a/admin/trustmarks/lib.py
+++ b/admin/trustmarks/lib.py
@@ -12,6 +12,10 @@ class TrustMarkRequest(BaseModel):
     tmt_select: str
 
 
+class TrustMarkTypeRequest(BaseModel):
+    type: str
+
+
 def add_trustmark(entity: str, trustmarktype: str, r: redis.Redis) -> str:
     """Adds a new subordinate to the federation.
 

--- a/admin/trustmarks/urls.py
+++ b/admin/trustmarks/urls.py
@@ -8,4 +8,7 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("add/", views.addtrustmark, name="addtrustmark"),
     path("list/", views.listtrustmarks, name="listtrustmarks"),
+    path("types/", views.type_index, name="type_index"),
+    path("types/add/", views.add_trustmark_type, name="add_type"),
+    path("types/list/", views.list_trustmark_types, name="list_types"),
 ]

--- a/admin/trustmarks/views.py
+++ b/admin/trustmarks/views.py
@@ -6,8 +6,8 @@ from django_redis import get_redis_connection
 
 from redis import Redis
 
-from .forms import TrustMarkForm
-from .lib import TrustMarkRequest, add_trustmark
+from .forms import TrustMarkForm, TrustMarkTypeForm
+from .lib import TrustMarkRequest, TrustMarkTypeRequest, add_trustmark
 from .models import TrustMark, TrustMarkType
 
 # Create your views here.
@@ -57,4 +57,43 @@ def addtrustmark(request: HttpRequest) -> HttpResponse:
         request,
         "trustmarks/add.html",
         {"form": form, "trustmarktypes": tmts, "msg": msg},
+    )
+
+
+def type_index(request: HttpRequest):
+    return render(request, "trustmark_types/index.html")
+
+
+def list_trustmark_types(request: HttpRequest):
+    trust_mark_types_list = TrustMarkType.objects.all()
+    paginator = Paginator(trust_mark_types_list, 3)
+
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+    return render(request, "trustmark_types/list.html", {"page_obj": page_obj})
+
+
+def add_trustmark_type(request: HttpRequest) -> HttpResponse:
+    msg = ""
+
+    if request.method == "POST":
+        form = TrustMarkTypeForm(request.POST)
+        # check whether it's valid:
+        if form.is_valid():
+            tmr = TrustMarkTypeRequest(type=form.data["type"])
+            trust_mark_type, created = TrustMarkType.objects.get_or_create(tmtype=tmr.type)
+            if created:
+                msg = f"Added {tmr.type}"
+            else:
+                msg = f"Trust mark type {tmr.type} was already present"
+        else:
+            print("invalid form")
+            msg = "Form validation failed."
+    else:
+        form = TrustMarkTypeForm(request.POST)
+
+    return render(
+        request,
+        "trustmark_types/add.html",
+        {"form": form, "msg": msg},
     )


### PR DESCRIPTION
This adds pages to list and add trust mark types from the "normal" web interface
(rather than having to go through django-admin).
It also fixes the root url to point at a generic index page.
When it's merged I'll update the wiki pages on usage.
